### PR TITLE
feat: Add compatibility with xiaomi-vacuum-map-card

### DIFF
--- a/custom_components/roomba_rest980/vacuum.py
+++ b/custom_components/roomba_rest980/vacuum.py
@@ -204,3 +204,45 @@ class RoombaVacuum(CoordinatorEntity, StateVacuumEntity):
             },
             blocking=True,
         )
+
+    async def async_send_command(
+        self,
+        command: str,
+        params: dict[str, Any] | list[Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Send a command to a vacuum cleaner."""
+
+        if command == "start":
+            regions = [
+                {
+                    "type": "rid",
+                    "region_id": region.get("region_id"),
+                    "params": {
+                        "noAutoPasses": False,
+                        "twoPass": region.get("params", {}).get("twoPass"),
+                     },
+                }
+                for region in params.get("regions", [])
+            ]
+
+            if regions:
+                payload = {
+                    "ordered": 1,
+                    "pmap_id": self._attr_extra_state_attributes.get("pmap0_id", ""),
+                    "regions": regions,
+                }
+            else:
+                payload = {"action": "start"}
+
+            await self.hass.services.async_call(
+                DOMAIN,
+                "rest980_clean",
+                service_data={
+                    "payload": payload,
+                    "base_url": self._entry.data["base_url"],
+                },
+                blocking=True,
+            )
+        else:
+            raise NotImplementedError(f"Command not implemented: {command}")


### PR DESCRIPTION
A proof of concept for: https://github.com/ia74/roomba_rest980/issues/21

### Description

As per the [documentation](https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card/blob/master/docs/templates/roomba.md), the Xiaomi Vacuum Map Card for Roombas uses `vacuum.send_command` to initiate room-specific cleaning jobs. This change overrides the standard behavior of `async_send_command` of `StateVacuumEntity` found [here](https://github.com/home-assistant/core/blob/28027ddca42eca114863086d336de17646f04c94/homeassistant/components/vacuum/__init__.py#L404-L416), which was  previously raising `NotImplementedError`... due to not being implemented, as the error would suggest :laughing:.


### Testing

Manually identified each region ID. You can follow the steps under `Add Controls For Specific Room & Zone Cleaning` in this [guide](https://blog.hessindustria.com/home-assistant-roomba-s9-integration/) to do this, but I just logged this payload, removed the API call that follows, and noted the region ID as I triggered a cleaning job for each of my rooms one by one 
https://github.com/ia74/roomba_rest980/blob/14eed4681aca87afc946d1ad15a7d1b87690c0e7/custom_components/roomba_rest980/vacuum.py#L141-L156

Once I had the card configured, I was able to run a job by using the interactive map on the card (i.e. you can select room(s) on the map, select 1x or 2x, then press start).