### PR TITLE
Fix KeyError for Favorites

### DIFF
--- a/custom_components/roomba_rest980/button.py
+++ b/custom_components/roomba_rest980/button.py
@@ -40,7 +40,7 @@ class FavoriteButton(ButtonEntity):
         self._attr_extra_state_attributes = data
         self._data = data
         self._attr_icon = "mdi:star"
-        self._attr_entity_registry_enabled_default = not data["hidden"]
+        self._attr_entity_registry_enabled_default = not data.get("hidden", False)
         self._attr_device_info = {
             "identifiers": {(DOMAIN, entry.unique_id)},
             "name": entry.title,


### PR DESCRIPTION
The `hidden` attribute of data regarding the cleaning favorites coming from the cloud API seems to be optional.  
In case it is not present, a `KeyError` is raised and no favorites are available.

This has been reported as issue #26 and is fixed with this PR (also thanks @ShortPutt)
``` 
Error while setting up roomba_rest980 platform for button: 'hidden'
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 454, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/config/custom_components/roomba_rest980/button.py", line 26, in async_setup_entry
    [FavoriteButton(entry, fav) for fav in cloud_data["favorites"]]
     ~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/config/custom_components/roomba_rest980/button.py", line 43, in __init__
    self._attr_entity_registry_enabled_default = not data["hidden"]
                                                     ~~~~^^^^^^^^^^
KeyError: 'hidden'
```
