### PR TITLE
Fix: Prevent setup blocking to allow multiple devices (Roomba & Braava) to initialize properly

### DIFF
--- a/custom_components/roomba_rest980/__init__.py
+++ b/custom_components/roomba_rest980/__init__.py
@@ -60,7 +60,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if entry.data["cloud_api"]:
         cloud_coordinator = RoombaCloudCoordinator(hass, entry)
         try:
-            await cloud_coordinator.async_config_entry_first_refresh()
 
             # Start background task for cloud setup and BLID matching
             hass.async_create_task(
@@ -159,6 +158,9 @@ async def _async_setup_cloud(
 ) -> None:
     """Set up cloud coordinator and perform BLID matching in background."""
     try:
+        if cloud_coordinator:
+            await cloud_coordinator.async_config_entry_first_refresh()
+
         # Perform BLID matching only if not already stored in config entry
         if "robot_blid" not in entry.data:
             matched_blid = await _async_match_blid(

--- a/custom_components/roomba_rest980/sensor.py
+++ b/custom_components/roomba_rest980/sensor.py
@@ -335,7 +335,8 @@ class RoombaCloudAttributes(RoombaCloudSensor):
     @property
     def extra_state_attributes(self):
         """Return all the attributes returned by iRobot's cloud."""
-        return self.coordinator.data.get(self._entry.runtime_data.robot_blid) or {}
+        data = self.coordinator.data or {}
+        return data.get(self._entry.runtime_data.robot_blid) or {}
 
 
 class RoombaCloudPmap(RoombaCloudSensor):


### PR DESCRIPTION
## Description
This PR fixes an issue where multiple devices fail to initialize properly in Home Assistant. In my specific use case, I have 1 Roomba and 1 Braava. The original blocking call to `cloud_coordinator.async_config_entry_first_refresh()` in the main `async_setup_entry` thread caused the setup of the second device to hang or fail during initialization.

## Changes Made
- Moved the `async_config_entry_first_refresh()` call inside the `_async_setup_cloud` background task to prevent blocking the main setup loop.
- Added a safe `None` check for `coordinator.data` in `sensor.py` (`RoombaCloudAttributes.extra_state_attributes`) to prevent an `AttributeError` when the sensor attempts to access the data before the background fetch completes.

Tested locally and confirmed both my Roomba and Braava now initialize and run perfectly side-by-side without blocking each other.