### PR TITLE
Fix job initiator enum fallback

### DIFF
--- a/custom_components/roomba_rest980/sensor.py
+++ b/custom_components/roomba_rest980/sensor.py
@@ -546,7 +546,7 @@ class RoombaJobInitiator(RoombaSensor):
         """Create a new job initiator reading."""
         super().__init__(coordinator, entry)
         self._attr_device_class = SensorDeviceClass.ENUM
-        self._attr_options = list(jobInitiatorMappings.values())
+        self._attr_options = list(jobInitiatorMappings.values()) + ["Unknown"]
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_icon = "mdi:cursor-pointer"
 


### PR DESCRIPTION
The Job Initiator sensor is declared as an enum sensor and its options are built from `jobInitiatorMappings.values()`.

When `cleanMissionStatus.initiator` contains an unmapped value, the sensor currently falls back to `"Unknown"`, but `"Unknown"` is not included in the enum options. Recent Home Assistant versions validate enum sensor states and raise a `ValueError` when the native value is not in the options list.

This adds `"Unknown"` to the enum options so the existing fallback remains valid.

Observed error:

```text
ValueError: Sensor sensor.<robot>_job_initiator provides state value 'Unknown', which is not in the list of options provided
```

Tested with:

```bash
python3 -m py_compile custom_components/roomba_rest980/sensor.py custom_components/roomba_rest980/const.py
```
