### PR TITLE
Fix cloud robot matching for models with mismatched SKU

### DIFF
--- a/custom_components/roomba_rest980/__init__.py
+++ b/custom_components/roomba_rest980/__init__.py
@@ -207,12 +207,19 @@ async def _async_match_blid(
                 local_sw_ver = local_data.get("softwareVer")
                 local_sku = local_data.get("sku")
 
-                # Match robots by SKU, software version, and name
-                if (
-                    cloud_sku == local_sku
-                    and cloud_sw_ver == local_sw_ver
-                    and cloud_name == local_name
-                ):
+                # Match robots using a scoring system to handle mismatches.
+                # Some models (e.g. Roomba Combo J9+) report the serial number
+                # prefix as SKU locally (c975840) while the cloud returns the
+                # actual product SKU (C910840). Software version format can
+                # also differ (local: "topaz+1.12.11+..." vs cloud: "1.12.11").
+                score = 0
+                if cloud_name and local_name and cloud_name.lower() == local_name.lower():
+                    score += 2
+                if cloud_sku and local_sku and cloud_sku.lower() == local_sku.lower():
+                    score += 1
+                if cloud_sw_ver and local_sw_ver and cloud_sw_ver in local_sw_ver:
+                    score += 1
+                if score >= 2:
                     entry.runtime_data.robot_blid = blid
                     _LOGGER.debug("Matched local Roomba with cloud robot %s", blid)
                     break


### PR DESCRIPTION
## Summary

- Fix cloud robot matching that fails on some models (e.g. Roomba Combo J9+) where the local SKU differs from the cloud SKU
- Replace strict equality check with a scoring system that handles SKU, software version format, and case mismatches

## Problem

The `_async_match_blid` function matches local and cloud robots using an exact comparison of SKU, software version, and name. On some models like the Roomba Combo J9+:
- **Local SKU** is `c975840` (serial number prefix), **cloud SKU** is `C910840` (product SKU) — different values
- **Local softwareVer** is `topaz+1.12.11+2025-04-30-...`, **cloud softwareVer** is `1.12.11` — different format

This causes the match to always fail with: `Could not match local Roomba with any cloud robot`

Fixes #41

## Solution

Replace the strict AND of all three fields with a scoring system:

| Criterion | Points | Rationale |
|---|---|---|
| Name (case-insensitive) | 2 | Most reliable — user-chosen, unique in practice |
| SKU (case-insensitive) | 1 | Unreliable on some models (serial prefix vs product SKU) |
| Software version (substring match) | 1 | Format differs between local and cloud |

Threshold: score ≥ 2 to match.

## Test plan

- [x] Tested on Roomba Combo J9+ (SKU C910840, local reports c975840)
- [x] Cloud features (rooms, favorites, map) load correctly after fix
- [x] Warning `Could not match local Roomba with any cloud robot` no longer appears in logs