### PR TITLE
feat: add show_zones option for a rooms-only map

### DIFF
--- a/custom_components/roomba_rest980/__init__.py
+++ b/custom_components/roomba_rest980/__init__.py
@@ -80,10 +80,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Register services
     await _async_register_services(hass)
 
+    # Reload the entry when its options change (e.g. show_zones toggle)
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
     # Forward platforms; create tasks but await to ensure no failure?
     await hass.config_entries.async_forward_entry_setups(entry, ["vacuum", "sensor"])
 
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the integration when its options are updated."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def _async_register_services(hass: HomeAssistant) -> None:

--- a/custom_components/roomba_rest980/camera.py
+++ b/custom_components/roomba_rest980/camera.py
@@ -238,8 +238,9 @@ class RoombaMapCamera(Camera):
                         # Draw coordinate points (walls/obstacles)
                         self._draw_points(draw, offset_x, offset_y, scale)
 
-                        # Draw zones (keepout, clean, observed)
-                        img = self._draw_zones(img, offset_x, offset_y, scale)
+                        # Draw zones (keepout, clean, observed) unless disabled
+                        if self._entry.options.get("show_zones", True):
+                            img = self._draw_zones(img, offset_x, offset_y, scale)
 
         # Convert to bytes
         img_bytes = io.BytesIO()

--- a/custom_components/roomba_rest980/config_flow.py
+++ b/custom_components/roomba_rest980/config_flow.py
@@ -8,7 +8,8 @@ from aiohttp import ClientConnectorError, ClientError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
+from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .CloudApi import AuthenticationError, iRobotCloudApi
@@ -43,6 +44,12 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     _proposed_name: str
     _user_data: dict[str, any]
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> "RoombaOptionsFlow":
+        """Get the options flow for this handler."""
+        return RoombaOptionsFlow()
 
     async def async_step_reauth(self, entry_data: dict[str, any]) -> ConfigFlowResult:
         """Perform reauth upon an API authentication error."""
@@ -131,3 +138,23 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._user_data = user_input
             return self.async_show_form(step_id="cloud", data_schema=CLOUD_SCHEMA)
         return self.async_show_form(step_id="user", data_schema=USER_SCHEMA)
+
+
+class RoombaOptionsFlow(config_entries.OptionsFlow):
+    """Handle options for the Roomba integration."""
+
+    async def async_step_init(self, user_input=None) -> ConfigFlowResult:
+        """Manage the map rendering options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        options = self.config_entry.options
+        options_schema = vol.Schema(
+            {
+                vol.Required(
+                    "show_zones",
+                    default=options.get("show_zones", True),
+                ): bool,
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=options_schema)

--- a/custom_components/roomba_rest980/translations/en.json
+++ b/custom_components/roomba_rest980/translations/en.json
@@ -30,5 +30,18 @@
     "abort": {
       "missing_user_data": "Forgot the local Rest980 data."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Map options",
+        "data": {
+          "show_zones": "Show zones on the map"
+        },
+        "data_description": {
+          "show_zones": "Draw keep-out, clean, and observed zones on the map image. Turn this off for a rooms-only map."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## What

Adds a **`show_zones`** toggle to the integration's options flow (Settings → Devices & Services → the Roomba integration → **Configure**).

When enabled (the default), the map camera renders as it does today. When **disabled**, `_render_map()` skips `_draw_zones()`, producing a clean **rooms-and-labels-only** map.

## Why

The map camera renders keep-out, clean, and observed zones on top of the room polygons. On dashboards — e.g. the recommended [xiaomi-vacuum-map-card](https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card) — those overlays clutter the room labels and selection outlines. A rooms-only map is much easier to read and tap.

## Changes

- `config_flow.py` — add `RoombaOptionsFlow` + `async_get_options_flow`
- `camera.py` — gate `_draw_zones()` on `self._entry.options.get("show_zones", True)`
- `__init__.py` — add an options-update listener that reloads the entry so the map re-renders immediately on toggle
- `translations/en.json` — strings for the new option

## Notes

- Defaults to `True`, so existing setups are unchanged.
- No new dependencies; `_draw_zones` and its helpers are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)